### PR TITLE
Fix titles overflow on product details page

### DIFF
--- a/assets/scss/custom/_grid.scss
+++ b/assets/scss/custom/_grid.scss
@@ -97,6 +97,6 @@
 }
 
 .overflow-visible {
-    overflow: visible;
+    overflow: visible !important;
 }
 


### PR DESCRIPTION
<img width="439" alt="Снимок экрана 2020-09-30 в 17 16 40" src="https://user-images.githubusercontent.com/22875828/94704952-c605ef00-0340-11eb-8580-6f8ae29379e5.png">
