### PR TITLE
VP-4973: Load actual prices on product page

### DIFF
--- a/assets/js/controllers/price.js
+++ b/assets/js/controllers/price.js
@@ -1,9 +1,9 @@
-﻿var storefrontApp = angular.module('storefrontApp');
+var storefrontApp = angular.module('storefrontApp');
 
 storefrontApp.controller('priceController', ['$scope', '$window', 'pricingService', 'loadingIndicatorService', function ($scope, $window, pricingService, loader) {
     $scope.loader = loader;
     loader.wrapLoading(function() {
-        return pricingService.getActualProductPrices($window.products).then(function(response) {
+        return pricingService.getActualProductPrices($window.products || [$window.product]).then(function(response) {
             var prices = response.data;
             $scope.prices = _.object(_.map(prices, function(price) {
                 return [price.productId, price];


### PR DESCRIPTION
Depend on https://github.com/VirtoCommerce/vc-demo-storefront/pull/26
Without it will _introduce_ VP-4973 on product page, because it share code with category page.